### PR TITLE
Python 3 Compatibility and Auto_Dataset Fixes

### DIFF
--- a/aetros/AetrosBackend.py
+++ b/aetros/AetrosBackend.py
@@ -8,6 +8,7 @@ import requests
 import signal
 import json
 import time
+import numpy
 
 from io import BytesIO
 # from requests.auth import HTTPBasicAuth
@@ -18,6 +19,13 @@ def dict_factory(cursor, row):
     for idx, col in enumerate(cursor.description):
         d[col[0]] = row[idx]
     return d
+
+def invalid_json_values(obj):
+    if isinstance(obj, numpy.generic):
+        return obj.item()
+    if isinstance(obj, numpy.ndarray):
+        return obj.tolist()
+    raise TypeError('Invalid json value passed to encoder')
 
 
 class EventListener:
@@ -246,12 +254,24 @@ class AetrosBackend:
         return response.json()
 
     def get(self, url, params=None, **kwargs):
+        json_chunk = kwargs.get('json')
+        if (json_chunk and not isinstance(json_chunk, str)):
+            kwargs['json'] = json.loads(json.dumps(json_chunk, default=invalid_json_values))
+        
         return requests.get(self.get_url(url), params=params, **kwargs)
 
     def post(self, url, data=None, **kwargs):
+        json_chunk = kwargs.get('json')
+        if (json_chunk and not isinstance(json_chunk, str)):
+            kwargs['json'] = json.loads(json.dumps(json_chunk, default=invalid_json_values))
+        
         return requests.post(self.get_url(url), data=data, **kwargs)
 
     def put(self, url, data=None, **kwargs):
+        json_chunk = kwargs.get('json')
+        if (json_chunk and not isinstance(json_chunk, str)):
+            kwargs['json'] = json.loads(json.dumps(json_chunk, default=invalid_json_values))
+        
         return requests.put(self.get_url(url), data=data, **kwargs)
 
     def create_job(self, name, server_id='local', dataset_id=None, insights=False):
@@ -270,9 +290,9 @@ class AetrosBackend:
             'id': network_name,
             'type': network_type,
             'model': model_json,
-            'settings': json.dumps(settings, allow_nan=False) if settings else None,
-            'layers': json.dumps(layers, allow_nan=False),
-            'graph': json.dumps(graph, allow_nan=False),
+            'settings': json.dumps(settings, allow_nan=False, default=invalid_json_values) if settings else None,
+            'layers': json.dumps(layers, allow_nan=False, default=invalid_json_values),
+            'graph': json.dumps(graph, allow_nan=False, default=invalid_json_values),
         })
 
         if response.status_code != 200:
@@ -321,7 +341,7 @@ class AetrosBackend:
         return self.post('job/started', {'id': id, 'pid': pid})
 
     def job_add_status(self, statusKey, statusValue):
-        item = {'statusKey': statusKey, 'statusValue': json.dumps(statusValue, allow_nan=False)}
+        item = {'statusKey': statusKey, 'statusValue': json.dumps(statusValue, allow_nan=False, default=invalid_json_values)}
 
         self.queueLock.acquire()
         self.queue.append({

--- a/aetros/AetrosBackend.py
+++ b/aetros/AetrosBackend.py
@@ -25,7 +25,9 @@ def invalid_json_values(obj):
         return obj.item()
     if isinstance(obj, numpy.ndarray):
         return obj.tolist()
-    raise TypeError('Invalid json value passed to encoder')
+    if isinstance(obj, bytes):
+        return obj.decode('cp437')
+    raise TypeError('Invalid data type passed to json encoder: ' + type(obj))
 
 
 class EventListener:

--- a/aetros/KerasLogger.py
+++ b/aetros/KerasLogger.py
@@ -8,6 +8,7 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
+from io import BytesIO
 
 import PIL.Image
 import math
@@ -465,7 +466,9 @@ class KerasLogger(Callback):
                 dict[k] = -1
 
     def to_base64(self, image):
-        buffer = StringIO()
+        buffer = BytesIO()
+        if (six.PY2):
+            buffer = StringIO()
         image.save(buffer, format="JPEG", optimize=True, quality=80)
         return base64.b64encode(buffer.getvalue())
 

--- a/aetros/auto_dataset.py
+++ b/aetros/auto_dataset.py
@@ -19,6 +19,7 @@ from PIL import Image
 
 from aetros.utils import get_option
 from .network import ensure_dir
+from .AetrosBackend import invalid_json_values
 
 from threading import Thread, Lock
 from six.moves.queue import Queue
@@ -412,7 +413,7 @@ def get_images(job_model, dataset, node, trainer):
     classes_changed = False
     config_changed = False
     had_previous = False
-    classes_md5 = hashlib.md5(json.dumps(classes)).hexdigest()
+    classes_md5 = hashlib.md5(json.dumps(classes, default=invalid_json_values)).hexdigest()
 
     validationFactor = 0.2
 
@@ -501,7 +502,7 @@ def get_images(job_model, dataset, node, trainer):
                     'classes_md5': classes_md5,
                     'config': config
                 }
-                json.dump(meta, f)
+                json.dump(meta, f, default=invalid_json_values)
 
         except KeyboardInterrupt:
             controller['running'] = False

--- a/aetros/auto_dataset.py
+++ b/aetros/auto_dataset.py
@@ -413,7 +413,7 @@ def get_images(job_model, dataset, node, trainer):
     classes_changed = False
     config_changed = False
     had_previous = False
-    classes_md5 = hashlib.md5(json.dumps(classes, default=invalid_json_values)).hexdigest()
+    classes_md5 = hashlib.md5(json.dumps(classes, default=invalid_json_values).encode('utf-8')).hexdigest()
 
     validationFactor = 0.2
 

--- a/aetros/network.py
+++ b/aetros/network.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 from __future__ import absolute_import
 import json
 import os
+from .AetrosBackend import invalid_json_values
 from pprint import pprint
 import six
 from six.moves import range
@@ -76,8 +77,8 @@ def job_start(job_model, trainer, keras_logger, general_logger):
 
     trainer.set_status('LOAD DATA')
     datasets = job_model.network_get_datasets(trainer)
-    general_logger.write('trainer.input_shape = %s\n' % (json.dumps(trainer.input_shape),))
-    general_logger.write('trainer.classes = %s\n' % (json.dumps(trainer.classes),))
+    general_logger.write('trainer.input_shape = %s\n' % (json.dumps(trainer.input_shape, default=invalid_json_values),))
+    general_logger.write('trainer.classes = %s\n' % (json.dumps(trainer.classes, default=invalid_json_values),))
 
     dataset_infos = {}
     for idx, dataset in six.iteritems(datasets):

--- a/aetros/predict.py
+++ b/aetros/predict.py
@@ -15,7 +15,7 @@ from PIL import Image
 from aetros import network
 from aetros.network import ensure_dir
 from .JobModel import JobModel
-from .AetrosBackend import AetrosBackend
+from .AetrosBackend import AetrosBackend, invalid_json_values
 
 
 def predict(job_id, file_paths, insights=False, weights_path=None):
@@ -67,4 +67,4 @@ def predict(job_id, file_paths, insights=False, weights_path=None):
     print("Start prediction ...")
 
     prediction = job_model.predict(model, np.array(inputs))
-    print(json.dumps(prediction, indent=4))
+    print(json.dumps(prediction, indent=4, default=invalid_json_values))

--- a/aetros/utils/image.py
+++ b/aetros/utils/image.py
@@ -335,7 +335,7 @@ def get_layer_vis_square(data,
         if width > 1:
             padsize = 1
             width += 1
-        n = max(max_width / width, 1)
+        n = max(max_width // width, 1)
         n *= n
         data = data[:n]
 


### PR DESCRIPTION
Should fix various bugs without breaking Python 2.6 compatibility. Covers JSON serialization, string buffer, threads that don't exit, and deleting unclosed files.
I wasn't sure which JSON needed sanitization, so I covered all the potential ones. The loads(dumps(...)) bit from AetrosBackend is not ideal. I was just going to dump it to a string, but requests or the server gives an error, so I have to convert it back to a dict. It's not slow, though. Takes less than a millisecond, usually.
Let me know if I did something wrong. I've never made a pull request before. :)